### PR TITLE
misc fixes

### DIFF
--- a/pkg/workload/workerpool.go
+++ b/pkg/workload/workerpool.go
@@ -116,7 +116,7 @@ func (w *WorkerPool) Load(tableName string) error {
 			Statement:       stmt,
 			GeneratorMap:    genMap,
 			Batch:           true,
-			BatchSize:       500,
+			BatchSize:       5,
 			WaitGroup:       &w.wg,
 			MetricsRegistry: w.MetricsRegistry,
 		}


### PR DESCRIPTION
- Change default rows per batch to 5 during load jobs (previously 500) during load phase
- Explicitly close read transactions during run phase